### PR TITLE
btl inventory setups compatibility

### DIFF
--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=d19bdb2c5e86bab962615ae4b61976e0f3bcf9fa
+commit=5a72db686c63e6d32f69bb54d1d7317926649544

--- a/plugins/bank-tag-layouts
+++ b/plugins/bank-tag-layouts
@@ -1,2 +1,2 @@
 repository=https://github.com/geheur/bank-tag-custom-layouts.git
-commit=2927d889813a01cec11bc61845ec4f541111938f
+commit=d19bdb2c5e86bab962615ae4b61976e0f3bcf9fa

--- a/plugins/better-skill-tooltips
+++ b/plugins/better-skill-tooltips
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=1873e94adae057b644024e64493af294ab13bfdb
+repository=https://github.com/Enriath/external-plugins.git
+commit=f8f76c059762306b85407331408d8920f9ba4634

--- a/plugins/coffin-counter
+++ b/plugins/coffin-counter
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=0cb53d17e8747272d525a5bcaed275edc4e0ec0c
+repository=https://github.com/Enriath/external-plugins.git
+commit=651d56aa8822df616edfa45a65184e9d2d5165fa

--- a/plugins/contextual-cursor
+++ b/plugins/contextual-cursor
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=63a8a6c6e37f07730338db4ecfc8fde9502113f5
+repository=https://github.com/Enriath/external-plugins.git
+commit=8b274d6f8ef5562118a82bad8070eea01fee7aa5

--- a/plugins/crate-limiter
+++ b/plugins/crate-limiter
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=fa444ba479d412c81967d0b51cd9a4a145e1a129
+repository=https://github.com/Enriath/external-plugins.git
+commit=0e62b128479e8a2ce6201900757bfd2ceccd27f9

--- a/plugins/damage-counter
+++ b/plugins/damage-counter
@@ -1,2 +1,2 @@
 repository=https://github.com/0anth/damage-counter.git
-commit=a79fdfa5aa601cbad205a2037f8499def620317e
+commit=4cc2b8331d7e8acdbec30687db65a0607945e2da

--- a/plugins/discordnotificationsaio
+++ b/plugins/discordnotificationsaio
@@ -1,0 +1,3 @@
+repository=https://github.com/skyhawkgaming/better-discord-loot-logger.git
+commit=ec4c0ddc9b1773afd8a722406935426fb1561996
+warning=This plugin submits your username to wiseoldman.net.

--- a/plugins/dont-eat-it
+++ b/plugins/dont-eat-it
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=fcedf02026b7fd32f90fee97a7898c6be30eb24c
+repository=https://github.com/Enriath/external-plugins.git
+commit=75bf3501c3fa72a74548a54593d52ce0b8de6b7c

--- a/plugins/door-kicker
+++ b/plugins/door-kicker
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=04dfc0e0974b28080599bb1ffdc3f7195df922d6
+repository=https://github.com/Enriath/external-plugins.git
+commit=9d078ca73f670d14b23bbb776ffd75075bec69f3

--- a/plugins/dryness-calculator
+++ b/plugins/dryness-calculator
@@ -1,2 +1,2 @@
 repository=https://github.com/Jallah123/Dry-Calculator.git
-commit=a854d679a16655b897560ecf8f9768077227fd36
+commit=fda341b93062a4c7f96729e6c8d2a42b8c105eb1

--- a/plugins/fight-cave-helper
+++ b/plugins/fight-cave-helper
@@ -1,0 +1,2 @@
+repository=https://github.com/runkev/fight-cave-helper.git
+commit=b53d18931f9f3abf6e41b41ddf0bc31c04def9ab

--- a/plugins/flipping-utilities
+++ b/plugins/flipping-utilities
@@ -1,3 +1,3 @@
 repository=https://github.com/Flipping-Utilities/rl-plugin.git
-commit=7c939316ca60391a45b96cfcd9e5a97ff815412a
+commit=089d694bdda1d52c85c6f79cfdd70f6f4c954776
 authors=zumaad

--- a/plugins/home-enforcer
+++ b/plugins/home-enforcer
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=d93518a6c987b659ec2f5363dc42f4ac584944a7
+repository=https://github.com/Enriath/external-plugins.git
+commit=2b8e96625716091964ae707f19a42359f43364d3

--- a/plugins/inventory-summary
+++ b/plugins/inventory-summary
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=9e13acf299b13e267c07f3b6e4c142065b874c53
+repository=https://github.com/Enriath/external-plugins.git
+commit=a77a225fa3fc9287e0409ba6e21b488013c84a97

--- a/plugins/item-stats-banking
+++ b/plugins/item-stats-banking
@@ -1,0 +1,2 @@
+repository=https://github.com/Boredska/bank-item-stats-toggle.git
+commit=b9d65c7472e59224895ff13b05bd459c81661a32

--- a/plugins/master-scroll-book
+++ b/plugins/master-scroll-book
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=f268b5ed60e6b6b5b6231db97db6444a87726672
+repository=https://github.com/Enriath/external-plugins.git
+commit=f46cd0b2728d44aabe2a38240d44edc979f96644

--- a/plugins/neverscapealone
+++ b/plugins/neverscapealone
@@ -1,4 +1,4 @@
 repository=https://github.com/NeverScapeAlone/never-scape-alone.git
-commit=d7e5e5615627916ef11594c7ae63cc44549c991f
+commit=a5958f4785581e1e67aa71772ff3e3d59e09bbbe
 warning=This plugin submits your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.
 authors=Ferrariic

--- a/plugins/party-panel
+++ b/plugins/party-panel
@@ -1,2 +1,3 @@
 repository=https://github.com/TheStonedTurtle/party-panel.git
 commit=377be8785f50eeab5435b00792c2da54d474abc1
+disabled=true

--- a/plugins/plank-sack
+++ b/plugins/plank-sack
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=2ee2bc11367a402a1d553f1b1290965ee6f81143
+repository=https://github.com/Enriath/external-plugins.git
+commit=e95ce398fe2cfa427aeb8e3a91d4a19fb32bd0a3

--- a/plugins/pre-eoc-xp-drops
+++ b/plugins/pre-eoc-xp-drops
@@ -1,3 +1,3 @@
 repository=https://github.com/rsn-INVU/pre-eoc-xp-drops.git
 
-commit=c75a76f2fced4142bb8784b2c86fb9e5428c0ab9
+commit=141b5b65e222d9b19d8de6d5e90cbcfe88297c1f

--- a/plugins/qolting
+++ b/plugins/qolting
@@ -1,2 +1,2 @@
 repository=https://github.com/ArtsicleOfficial/Qolting.git
-commit=83e95d2c2cc77c1d0eadefaa9ea8bbec62eef5b5
+commit=deb12130b7acdda86a1628583bafcd176d5f90de

--- a/plugins/quick-prayer-preview
+++ b/plugins/quick-prayer-preview
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=ffa5d41c5dfc464c773681545107080645a8163b
+repository=https://github.com/Enriath/external-plugins.git
+commit=26b9cc5438abbb18b550da76aaf24cca7aa32278

--- a/plugins/random-event-analytics
+++ b/plugins/random-event-analytics
@@ -1,2 +1,2 @@
 repository=https://github.com/zmanowar/random-event-analytics.git
-commit=42060ea635b3a90b331b9b30867ccdefb8278c87
+commit=2c265a4147de4f16c78da764734ec0475047d132

--- a/plugins/shattered-relic-xp
+++ b/plugins/shattered-relic-xp
@@ -1,2 +1,3 @@
-repository=https://github.com/Hydrox6/external-plugins.git
+repository=https://github.com/Enriath/external-plugins.git
 commit=49c13e7a125bee291157e9be5199f02f89b0b6ea
+disabled=it's not leagues anymore

--- a/plugins/snailman-mode
+++ b/plugins/snailman-mode
@@ -1,2 +1,2 @@
 repository=https://github.com/IdylRS/snailman.git
-commit=1f2d3ba10ab8335214a8b74f96a3943da6dc6cfa
+commit=3322beefa5f8f46d00f4a79b174ae3aa41798052

--- a/plugins/star-calling-assist
+++ b/plugins/star-calling-assist
@@ -1,3 +1,3 @@
 repository=https://github.com/zodaz/star-calling-assist.git
-commit=02aaa4d4deb77f26add3f852bcb75adfe11dd422
+commit=ef4568b00d17a051a6cf8164c00ec634bc94a5a3
 warning=This plugin submits your current world number and in game name along with your IP address to a 3rd party website not controlled or verified by the RuneLite Developers.

--- a/plugins/star-lore
+++ b/plugins/star-lore
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=590a64bea4fa8b12cea7e65fd90bd2a4dd2a843f
+repository=https://github.com/Enriath/external-plugins.git
+commit=9cbee4f144b6905ea76f8a28c237a71b502085ac

--- a/plugins/subtle-virtual-levels
+++ b/plugins/subtle-virtual-levels
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=94a9b3ce00be54a2954b4737c259d4b655987037
+repository=https://github.com/Enriath/external-plugins.git
+commit=075bea7a447f20da599e4290739ff225766de928

--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=e6b3f49d312d7c1ba4a086443f5ef38e21a2c7d1
+commit=7abcef672db3b21928d8a9939835a904f513e99d

--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
 repository=https://github.com/Enriath/external-plugins.git
-commit=7abcef672db3b21928d8a9939835a904f513e99d
+commit=4ca4181183020b91081f879fba4a7669e3b333b2

--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,2 @@
-repository=https://github.com/Hydrox6/external-plugins.git
-commit=cba928c578d392f898478531b4994e317b5fff90
+repository=https://github.com/Enriath/external-plugins.git
+commit=e6b3f49d312d7c1ba4a086443f5ef38e21a2c7d1

--- a/plugins/transmog
+++ b/plugins/transmog
@@ -1,2 +1,3 @@
 repository=https://github.com/Enriath/external-plugins.git
 commit=4ca4181183020b91081f879fba4a7669e3b333b2
+disabled=true

--- a/plugins/visual-metronome
+++ b/plugins/visual-metronome
@@ -1,2 +1,2 @@
 repository=https://github.com/vincent0955/Visual-metronome.git
-commit=2aec1bf21f6478236481ee820a9fc88e64865baf
+commit=db5ae9cc34ae386343f5aef20ba8ef968bbb4bf1


### PR DESCRIPTION
btl seems to work with the new inventory setups stuff as far as I can tell. I assume you want to make the pull request? This PR contains the new hash for btl so you can just copy it over.

`5a72db686c63e6d32f69bb54d1d7317926649544` is the hash btw if you don't want to look in the diff.